### PR TITLE
Fix uploads failing after one hour

### DIFF
--- a/EproEndpoint.swift
+++ b/EproEndpoint.swift
@@ -120,11 +120,7 @@ public enum EproEndpoint {
         autoreleasepool {
             let credentialsProvider = AWSSTSCredentialsProvider(accessKey: access_key_id, secretKey: secret_access_key, sessionKey: session_token, expirationDate: tokenExpirationDate)
             let configuration = AWSServiceConfiguration(region: region, credentialsProvider: credentialsProvider)
-//            //AWSServiceManager.default().defaultServiceConfiguration = configuration
-//            let transferUtility = AWSS3TransferUtility.default()
-//            transferUtility.register(with: configuration!, forKey: session_token)
-//
-//
+
             AWSS3TransferUtility.register(with: configuration!, forKey: access_key_id)
             let transferUtility = AWSS3TransferUtility.s3TransferUtility(forKey: access_key_id)
             let expression = AWSS3TransferUtilityUploadExpression()
@@ -141,7 +137,6 @@ public enum EproEndpoint {
                     print("File uploaded successfully")
                    mediUploadable.uploadCompleted(success: true, errorMessage: "", fileName: filename)
                  }
-               // mediUploadable.uploadCompleted(success: false, errorMessage: "unidentified error", fileName: filename)
                 AWSS3TransferUtility.remove(forKey:access_key_id)
              }
             
@@ -152,7 +147,6 @@ public enum EproEndpoint {
                    }else if let uploadTask = task.result{
                     Logger.info("Upload started...")
                    }
-                   // mediUploadable.uploadCompleted(success: false, errorMessage: "unidentified error", fileName: filename)
                    return nil
                }
         }

--- a/EproEndpoint.swift
+++ b/EproEndpoint.swift
@@ -120,8 +120,13 @@ public enum EproEndpoint {
         autoreleasepool {
             let credentialsProvider = AWSSTSCredentialsProvider(accessKey: access_key_id, secretKey: secret_access_key, sessionKey: session_token, expirationDate: tokenExpirationDate)
             let configuration = AWSServiceConfiguration(region: region, credentialsProvider: credentialsProvider)
-            AWSServiceManager.default().defaultServiceConfiguration = configuration
-            let transferUtility = AWSS3TransferUtility.default()
+//            //AWSServiceManager.default().defaultServiceConfiguration = configuration
+//            let transferUtility = AWSS3TransferUtility.default()
+//            transferUtility.register(with: configuration!, forKey: session_token)
+//
+//
+            AWSS3TransferUtility.register(with: configuration!, forKey: access_key_id)
+            let transferUtility = AWSS3TransferUtility.s3TransferUtility(forKey: access_key_id)
             let expression = AWSS3TransferUtilityUploadExpression()
             expression.setValue("AES256", forRequestHeader: "x-amz-server-side-encryption")
 
@@ -134,17 +139,20 @@ public enum EproEndpoint {
                     mediUploadable.uploadCompleted(success: false, errorMessage: error!.localizedDescription, fileName: filename)
                  }else{
                     print("File uploaded successfully")
-                    mediUploadable.uploadCompleted(success: true, errorMessage: "", fileName: filename)
+                   mediUploadable.uploadCompleted(success: true, errorMessage: "", fileName: filename)
                  }
+               // mediUploadable.uploadCompleted(success: false, errorMessage: "unidentified error", fileName: filename)
+                AWSS3TransferUtility.remove(forKey:access_key_id)
              }
             
-            transferUtility.uploadData(content_data, bucket: bucket_name, key: full_file_path, contentType: "text/plain", expression: expression, completionHandler: completionHandler).continueWith  { (task : AWSTask) -> AnyObject? in
+            transferUtility?.uploadData(content_data, bucket: bucket_name, key: full_file_path, contentType: "text/plain", expression: expression, completionHandler: completionHandler).continueWith  { (task : AWSTask) -> AnyObject? in
                    if let error = task.error{
                     Logger.error("upload error!")
                     mediUploadable.uploadCompleted(success: false, errorMessage: error.localizedDescription, fileName: filename)
                    }else if let uploadTask = task.result{
                     Logger.info("Upload started...")
                    }
+                   // mediUploadable.uploadCompleted(success: false, errorMessage: "unidentified error", fileName: filename)
                    return nil
                }
         }

--- a/EproEndpoint.swift
+++ b/EproEndpoint.swift
@@ -135,7 +135,7 @@ public enum EproEndpoint {
                     mediUploadable.uploadCompleted(success: false, errorMessage: error!.localizedDescription, fileName: filename)
                  }else{
                     print("File uploaded successfully")
-                   mediUploadable.uploadCompleted(success: true, errorMessage: "", fileName: filename)
+                    mediUploadable.uploadCompleted(success: true, errorMessage: "", fileName: filename)
                  }
                 AWSS3TransferUtility.remove(forKey:access_key_id)
              }


### PR DESCRIPTION
This PR resolves an issue where uploads would fail after one hour.  Our temporary STS credentials expire after one hour, however we generate new credentials every request.  The root cause of the failure was the `AWSServiceManager` `defaultServiceConfiguration` not accepting credential changes after initialization.  This is a known issue around the aws sdk, it is a intentional design decision by the aws team to prevent threading issues around the shared configuration object.  

The solution to handling multiple uploads with different temporary credentials is registering multiple configurations, each with a key.  After the uploads complete we can delete the individual temporary configurations from the `AWSS3TransferUtility` to prevent a memory leak. 

